### PR TITLE
Refactor arrow poly

### DIFF
--- a/addons/2d_curved_arrow/curved_arrow_2d.gd
+++ b/addons/2d_curved_arrow/curved_arrow_2d.gd
@@ -6,9 +6,9 @@ var curved_arrow_scene: PackedScene = load("res://addons/2d_curved_arrow/curved_
 
 @export_group("Arrow Properties")
 # the global position of the tip of the arrow
-@export var end_pos: Vector2 = Vector2(200, 200):
+@export var end_position: Vector2 = Vector2(200, 200):
     set(value):
-        end_pos = value
+        end_position = value
         if end_star: end_star.global_position = value
         if Engine.is_editor_hint(): queue_redraw()
 # tune this up or down to increase or decrease the amount of bend
@@ -71,7 +71,7 @@ func _init():
 
 func _get_configuration_warnings() -> PackedStringArray:
     var warnings: PackedStringArray = []
-    if end_pos == Vector2.ZERO:
+    if end_position == Vector2.ZERO:
         warnings.append("Start and end positions must be set")
     return warnings
 
@@ -94,26 +94,26 @@ func _draw():
     for child in arrow_group.get_children():
         child.queue_free()
 
-    if end_pos == Vector2.ZERO:
+    if end_position == Vector2.ZERO:
         return
 
     var start_pos:     Vector2 = global_position # start wherever the node's position is
-    var mid_point:     Vector2 = (start_pos + end_pos) / 2
-    var direction:     Vector2 = (end_pos - start_pos).normalized()
+    var mid_point:     Vector2 = (start_pos + end_position) / 2
+    var direction:     Vector2 = (end_position - start_pos).normalized()
     var perpendicular: Vector2 = Vector2(-direction.y, direction.x)
 
-    var diff:                 float = start_pos.x - end_pos.y
+    var diff:                 float = start_pos.x - end_position.y
     var calc_curve_factor:    float = lerp(-curve_height_factor, curve_height_factor, smoothstep(-100, 100, diff))
     var start_tangent_factor: float = curve_height_factor
     # this tapers off the curve at the end - we could make it adjustable, but it kind of distorts the
     # arrow if it's too hight, so ... shrug
     var end_tangent_factor:   float = 0.1
 
-    var control_point: Vector2 = mid_point + perpendicular * (end_pos - start_pos).length() * calc_curve_factor
+    var control_point: Vector2 = mid_point + perpendicular * (end_position - start_pos).length() * calc_curve_factor
 
     var curve: Curve2D = Curve2D.new()
     curve.add_point(start_pos, Vector2.ZERO, (control_point - start_pos) * start_tangent_factor)
-    curve.add_point(end_pos, (end_pos - control_point) * end_tangent_factor, Vector2.ZERO)
+    curve.add_point(end_position, (end_position - control_point) * end_tangent_factor, Vector2.ZERO)
 
     var all_points: PackedVector2Array = curve.get_baked_points()
     if all_points.size() < 5:
@@ -129,7 +129,7 @@ func _draw():
     var last_bottom_tip: Vector2
     for i in guide_points.size():
         var guide_point = guide_points[i]
-        if guide_point.distance_to(end_pos) < arrowhead_height: break
+        if guide_point.distance_to(end_position) < arrowhead_height: break
         # most likely we don't reach this point because of the height check, but this
         # is to protect us from going out of bounds
         if i+i_offset >= guide_points.size(): i_offset = max(i_offset - 1, 0)
@@ -144,7 +144,7 @@ func _draw():
 
     var arrow_pts: Array[Vector2] = [
         last_top_tip,
-        end_pos, # tip of the arrow!
+        end_position, # tip of the arrow!
         last_bottom_tip
     ]
 
@@ -185,7 +185,7 @@ func in_boundary_box(pos: Vector2) -> bool:
 # useful for setting to the coords of other nodes, or following the mouse
 func set_positions(start: Vector2, end: Vector2):
     position = start
-    end_pos = end
+    end_position = end
     queue_redraw()
 
 # in some cases, you may want to change these params while the arrow is moving or something,

--- a/addons/2d_curved_arrow/curved_arrow_2d.gd
+++ b/addons/2d_curved_arrow/curved_arrow_2d.gd
@@ -155,18 +155,13 @@ func _draw():
     arrow_poly.color = color
     arrow_group.add_child(arrow_poly)
 
-    if all_points.size() < 7:
-        return
-
-    # set up bounding ref - note: this doesn't do a good job of covering the curved line
-    # but once rewritten to be a single polygon it should be better
-    var combined_points: Array[Vector2] = top_side_points + bottom_side_points + arrow_pts
-    var x_vals: Array[float]
-    x_vals.assign(combined_points.map(func(p): return p.x))
-    var y_vals: Array[float]
-    y_vals.assign(combined_points.map(func(p): return p.y))
-    reference_rect.position = Vector2(x_vals.min(), y_vals.min())
-    reference_rect.size     = Vector2(x_vals.max() - x_vals.min(), y_vals.max() - y_vals.min())
+    if is_selected_in_editor:
+        # set up bounding ref - just a visual in the editor
+        var combined_points: Array[Vector2] = top_side_points + bottom_side_points + arrow_pts
+        var x_vals = combined_points.map(func(p: Vector2): return p.x)
+        var y_vals = combined_points.map(func(p: Vector2): return p.y)
+        reference_rect.position = Vector2(x_vals.min(), y_vals.min())
+        reference_rect.size     = Vector2(x_vals.max() - x_vals.min(), y_vals.max() - y_vals.min())
 
     # set visibility of editor helpers
     reference_rect.visible = is_selected_in_editor

--- a/addons/2d_curved_arrow/curved_arrow_plugin.gd
+++ b/addons/2d_curved_arrow/curved_arrow_plugin.gd
@@ -42,7 +42,7 @@ func _forward_canvas_draw_over_viewport(viewport_control: Control) -> void:
     _update_transforms()
 
     var pos_scale = _transform_to_view.get_scale()
-    var end_pos_offset = (_selected_node.end_pos - _selected_node.position) * pos_scale
+    var end_pos_offset = (_selected_node.end_position - _selected_node.position) * pos_scale
     _end_handle_pos = _transform_to_view.get_origin() + end_pos_offset
     # XXX: this makes a circle show up at the end of the arrow, but it
     # doesn't move with the mouse, so it's not great. May come back to this.
@@ -62,7 +62,7 @@ func _forward_canvas_gui_input(event: InputEvent) -> bool:
             return true
         _dragging_handle = false
     elif event is InputEventMouseMotion and _dragging_handle:
-        _selected_node.end_pos = _transform_to_base * event.position + _selected_node.position
+        _selected_node.end_position = _transform_to_base * event.position + _selected_node.position
         return true
 
     return false

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,10 @@ run/main_scene="res://test_scene.tscn"
 config/features=PackedStringArray("4.3", "GL Compatibility")
 config/icon="res://icon.svg"
 
+[display]
+
+window/stretch/mode="canvas_items"
+
 [editor_plugins]
 
 enabled=PackedStringArray("res://addons/2d_curved_arrow/plugin.cfg")

--- a/test_scene.gd
+++ b/test_scene.gd
@@ -14,7 +14,7 @@ func _input(event: InputEvent) -> void:
 
     # moving mouse? follow that mouse!
     if event is InputEventMouseMotion:
-        _arrow_follow_mouse.end_pos = event.position
+        _arrow_follow_mouse.end_position = event.position
         _arrow_follow_mouse.queue_redraw()
 
     # on click, deselect arrow

--- a/test_scene.tscn
+++ b/test_scene.tscn
@@ -10,7 +10,7 @@ script = ExtResource("1_4uvj7")
 [node name="CurvedArrow2D" type="Node2D" parent="."]
 position = Vector2(66, 154)
 script = ExtResource("1_gaug5")
-end_position = Vector2(211.519, 468.289)
+end_position = Vector2(242.948, 486.809)
 color = Color(0.469536, 0.716695, 0.887926, 1)
 width = 15.0
 arrowhead_height = 40.0
@@ -23,9 +23,9 @@ color = Color(4.09111e-07, 0.412488, 0.406186, 1)
 polygon = PackedVector2Array(2, -1, 257, 38, 302, 150, 305, 356, 91, 433, -62, 313, -54, 64)
 
 [node name="ChildCurvedArrow2D" type="Node2D" parent="PolygonBackground"]
-position = Vector2(45, 125)
+position = Vector2(94, 336)
 script = ExtResource("1_gaug5")
-end_position = Vector2(679, 389)
+end_position = Vector2(563.972, 146.142)
 color = Color(0.938248, 0.518122, 0.800277, 1)
 arrowhead_height = 30.0
 arrowhead_width = 100.0

--- a/test_scene.tscn
+++ b/test_scene.tscn
@@ -10,11 +10,10 @@ script = ExtResource("1_4uvj7")
 [node name="CurvedArrow2D" type="Node2D" parent="."]
 position = Vector2(66, 154)
 script = ExtResource("1_gaug5")
-end_pos = Vector2(255.856, 481.197)
+end_position = Vector2(211.519, 468.289)
 color = Color(0.469536, 0.716695, 0.887926, 1)
 width = 15.0
 arrowhead_height = 40.0
-arrowhead_width = 80.0
 outline_color = Color(0.2147, 0.648726, 0, 1)
 outline_thickness = 5
 
@@ -26,7 +25,7 @@ polygon = PackedVector2Array(2, -1, 257, 38, 302, 150, 305, 356, 91, 433, -62, 3
 [node name="ChildCurvedArrow2D" type="Node2D" parent="PolygonBackground"]
 position = Vector2(45, 125)
 script = ExtResource("1_gaug5")
-end_pos = Vector2(679.024, 389.716)
+end_position = Vector2(679, 389)
 color = Color(0.938248, 0.518122, 0.800277, 1)
 arrowhead_height = 30.0
 arrowhead_width = 100.0

--- a/test_scene.tscn
+++ b/test_scene.tscn
@@ -10,8 +10,11 @@ script = ExtResource("1_4uvj7")
 [node name="CurvedArrow2D" type="Node2D" parent="."]
 position = Vector2(66, 154)
 script = ExtResource("1_gaug5")
-end_pos = Vector2(255.886, 488.421)
+end_pos = Vector2(255.856, 481.197)
 color = Color(0.469536, 0.716695, 0.887926, 1)
+width = 15.0
+arrowhead_height = 40.0
+arrowhead_width = 80.0
 outline_color = Color(0.2147, 0.648726, 0, 1)
 outline_thickness = 5
 
@@ -23,8 +26,10 @@ polygon = PackedVector2Array(2, -1, 257, 38, 302, 150, 305, 356, 91, 433, -62, 3
 [node name="ChildCurvedArrow2D" type="Node2D" parent="PolygonBackground"]
 position = Vector2(45, 125)
 script = ExtResource("1_gaug5")
-end_pos = Vector2(722.609, 355.821)
+end_pos = Vector2(679.024, 389.716)
 color = Color(0.938248, 0.518122, 0.800277, 1)
+arrowhead_height = 30.0
+arrowhead_width = 100.0
 outline_color = Color(0.995776, 0, 0.290746, 1)
 transparency = 0.5
 


### PR DESCRIPTION
Instead of drawing a Line for the base of the arrow and a Polygon2D for the head, this commit rewrites it to be entirely a polygon, using the original curve as a guide and generating points to either side of it.

I also added an arrowhead width param to allow further tuning of the look of the arrowhead.